### PR TITLE
RxGestures: fix `takeUntil` warning.

### DIFF
--- a/Pod/Classes/OSX/NSGestureRecognizer+Rx.swift
+++ b/Pod/Classes/OSX/NSGestureRecognizer+Rx.swift
@@ -67,7 +67,7 @@ extension Reactive where Base: NSGestureRecognizer {
                 }
                 gestureTarget.dispose()
             }
-        }.takeUntil(self.deallocated)
+        }.take(until: self.deallocated)
 
         return ControlEvent(events: source)
     }

--- a/Pod/Classes/View+RxGesture.swift
+++ b/Pod/Classes/View+RxGesture.swift
@@ -102,7 +102,7 @@ extension Reactive where Base: View {
                     guard let gesture = gesture else { return }
                     control?.removeGestureRecognizer(gesture)
                 })
-                .takeUntil(control.rx.deallocated)
+                .take(until: control.rx.deallocated)
         }
 
         return ControlEvent(events: source)


### PR DESCRIPTION
This commit fixes the "takeUntil is deprecated" warning.